### PR TITLE
fixes #3; update print_cil_from_dn_file.py

### DIFF
--- a/dncil/cil/body/__init__.py
+++ b/dncil/cil/body/__init__.py
@@ -13,10 +13,10 @@ from typing import TYPE_CHECKING, List, Optional
 if TYPE_CHECKING:
     from dncil.cil.instruction import Instruction
     from dncil.cil.body.reader import CilMethodBodyReaderBase
-    from dncil.clr.token import Token
 
 from dncil.cil.enums import CorILMethod, CorILMethodSect
 from dncil.cil.error import MethodBodyFormatError
+from dncil.clr.token import Token
 from dncil.cil.exception import ExceptionHandler
 from dncil.cil.body.flags import CilMethodBodyFlags
 from dncil.cil.instruction import Instruction
@@ -98,7 +98,7 @@ class CilMethodBody:
                 # zero indicates there are no local variables
                 self.local_var_sig_tok = None
             else:
-                self.local_var_sig_tok = reader.get_token(local_var_sig_tok)
+                self.local_var_sig_tok = Token(local_var_sig_tok)
 
             # ECMA states fat format size is "currently" 3; we may need to change this calculation if that ever changes
             reader.seek(reader.tell() - 12 + self.header_size * 4)
@@ -168,7 +168,7 @@ class CilMethodBody:
             eh.handler_end = eh.handler_start + reader.read_uint32()[0]
 
             if eh.is_catch():
-                eh.catch_type = reader.get_token(reader.read_uint32()[0])
+                eh.catch_type = Token(reader.read_uint32()[0])
             elif eh.is_filter():
                 eh.filter_start = reader.read_uint32()[0]
             else:
@@ -194,7 +194,7 @@ class CilMethodBody:
             eh.handler_end = eh.handler_start + reader.read_uint8()[0]
 
             if eh.is_catch():
-                eh.catch_type = reader.get_token(reader.read_uint32()[0])
+                eh.catch_type = Token(reader.read_uint32()[0])
             elif eh.is_filter():
                 eh.filter_start = reader.read_uint32()[0]
             else:

--- a/dncil/clr/token.py
+++ b/dncil/clr/token.py
@@ -42,3 +42,13 @@ class InvalidToken(Token):
 
     def __str__(self):
         return "invalid token(0x%08X)" % self.value
+
+
+class StringToken(Token):
+    """store string managed token"""
+
+    def __init__(self, value):
+        super(StringToken, self).__init__(value)
+
+    def __str__(self):
+        return "string token(0x%08X)" % self.value


### PR DESCRIPTION
dncil now returns generic `Token` and `StringToken` objects; removes `get_token` function from base class.