### PR TITLE
read branch targets as signed integers

### DIFF
--- a/dncil/cil/body/reader.py
+++ b/dncil/cil/body/reader.py
@@ -111,7 +111,7 @@ class CilMethodBodyReaderBase(abc.ABC):
         branch_offset: int
         branch_offset_bytes: bytes
 
-        branch_offset, branch_offset_bytes = self.read_uint32()
+        branch_offset, branch_offset_bytes = self.read_int32()
         return insn.offset + insn.size + branch_offset, branch_offset_bytes
 
     def read_inline_field(self, insn: Instruction) -> Tuple[Token, bytes]:
@@ -179,7 +179,7 @@ class CilMethodBodyReaderBase(abc.ABC):
             branch_offset: int
             branch_offset_raw: bytes
 
-            branch_offset, branch_offset_raw = self.read_uint32()
+            branch_offset, branch_offset_raw = self.read_int32()
             branches.append(offset_after_insn + branch_offset)
             branches_bytes += branch_offset_raw
 
@@ -220,7 +220,7 @@ class CilMethodBodyReaderBase(abc.ABC):
         branch_offset: int
         branch_offset_bytes: bytes
 
-        branch_offset, branch_offset_bytes = self.read_uint8()
+        branch_offset, branch_offset_bytes = self.read_int8()
         return insn.offset + insn.size + branch_offset, branch_offset_bytes
 
     def read_short_inline_i(self, insn: Instruction) -> Tuple[int, bytes]:


### PR DESCRIPTION
As defined by the standard for CIL code, targets of branch and switch instructions are stored as _signed_ offsets [ECMA 335, Chapter III, 3.15 and 3.66].

Dncil previously read unsigned values in those cases, which caused issues for me. This is now fixed.

The code is probably based on dnlib, which in fact reads unsigned values and works just fine. Because dnlib is written in C#, an overflow will occur when negative offsets are encountered, so it still behaves like signed values were read. Such overflows do not occur in python, so the implementation has to differ from dnlib here.

There might be more of such issues hidden somewhere. Maybe it would be worth comparing the rest of the reader code to the specification as well...