### PR TITLE
add __int__, __hash__, __eq__ methods and missing annotations to Token, Local, and Argument classes

### DIFF
--- a/dncil/clr/argument.py
+++ b/dncil/clr/argument.py
@@ -20,3 +20,12 @@ class Argument:
 
     def __repr__(self) -> str:
         return str(self)
+    
+    def __int__(self) -> int:
+        return int(self.index)
+    
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Argument) and self.index == other.index
+
+    def __hash__(self) -> int:
+        return hash(self.index)

--- a/dncil/clr/local.py
+++ b/dncil/clr/local.py
@@ -20,3 +20,12 @@ class Local:
 
     def __repr__(self) -> str:
         return str(self)
+    
+    def __int__(self) -> int:
+        return int(self.index)
+    
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Local) and self.index == other.index
+
+    def __hash__(self) -> int:
+        return hash(self.index)

--- a/dncil/clr/token.py
+++ b/dncil/clr/token.py
@@ -6,49 +6,60 @@
 #  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 
 class Token(object):
     """store managed token"""
 
-    RID_MASK = 0x00FFFFFF
-    RID_MAX = RID_MASK
-    TABLE_SHIFT = 24
+    RID_MASK: int = 0x00FFFFFF
+    RID_MAX: int = RID_MASK
+    TABLE_SHIFT: int = 24
 
-    def __init__(self, value):
-        self.value = value
+    def __init__(self, value: int):
+        self.value: int = value
 
     @property
-    def rid(self):
+    def rid(self) -> int:
         """get token row index"""
         return self.value & Token.RID_MASK
 
     @property
-    def table(self):
+    def table(self) -> int:
         """get token table index"""
         return self.value >> Token.TABLE_SHIFT
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "token(0x%08X)" % self.value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
+
+    def __int__(self) -> int:
+        return int(self.value)
+    
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Token) and self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
 
 
 class InvalidToken(Token):
     """store invalid managed token"""
 
-    def __init__(self, value):
+    def __init__(self, value: int):
         super(InvalidToken, self).__init__(value)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "invalid token(0x%08X)" % self.value
 
 
 class StringToken(Token):
     """store string managed token"""
 
-    def __init__(self, value):
+    def __init__(self, value: int):
         super(StringToken, self).__init__(value)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "string token(0x%08X)" % self.value


### PR DESCRIPTION
Closes #16 and additionally works towards #8 

Chose to not declare these classes as subclasses of int due to possible issues regarding immutability of an instance and mainly compatibility, resulting in unpredictable behaviour (as these instances are expected to be valid substitutes for ints in operations which do not make sense for indices or tokens).

