### PR TITLE
dnfile 0.15.0 changed API

### DIFF
--- a/scripts/print_cil_from_dn_file.py
+++ b/scripts/print_cil_from_dn_file.py
@@ -52,7 +52,7 @@ class DnfileMethodBodyReader(CilMethodBodyReaderBase):
 def read_dotnet_user_string(pe: dnfile.dnPE, token: StringToken) -> Union[str, InvalidToken]:
     """read user string from #US stream"""
     try:
-        user_string: Optional[dnfile.stream.UserString] = pe.net.user_strings.get_us(token.rid)
+        user_string: Optional[dnfile.stream.UserString] = pe.net.user_strings.get(token.rid)
     except UnicodeDecodeError as e:
         return InvalidToken(token.value)
 

--- a/scripts/print_cil_from_dn_file.py
+++ b/scripts/print_cil_from_dn_file.py
@@ -56,7 +56,7 @@ def read_dotnet_user_string(pe: dnfile.dnPE, token: StringToken) -> Union[str, I
     except UnicodeDecodeError as e:
         return InvalidToken(token.value)
 
-    if user_string is None:
+    if user_string is None or user_string.value is None:
         return InvalidToken(token.value)
 
     return user_string.value

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
             "black==24.3.0",
             "isort==5.13.2",
             "mypy==1.9.0",
-            "dnfile==0.14.1",
+            "dnfile==0.15.0",
             "hexdump==3.3.0",
         ],
     },


### PR DESCRIPTION
dnfile v0.15.0 contains a breaking change.  The heap streams' .get() functions now return custom container objects instead of bytes. 