### PR TITLE
Add missing type annotations to core CIL classes

### DIFF
--- a/dncil/cil/body/flags.py
+++ b/dncil/cil/body/flags.py
@@ -25,8 +25,8 @@ class CilMethodBodyFlags:
         self.InitLocals: bool = bool(flags & CorILMethod.InitLocals)
         self.CompressedIL: bool = bool(flags & CorILMethod.CompressedIL)
 
-    def __str__(self):
-        def _to_print(v):
+    def __str__(self) -> str:
+        def _to_print(v: bool) -> str:
             return "true" if v else "false"
 
         return (
@@ -39,7 +39,7 @@ class CilMethodBodyFlags:
             + f"CompressedIL :  {_to_print(self.CompressedIL)}\n"
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
     def is_tiny(self) -> bool:

--- a/dncil/cil/instruction.py
+++ b/dncil/cil/instruction.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class Instruction:
     """store managed instruction"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.offset: int
         self.opcode: OpCode
         self.opcode_bytes: bytes
@@ -45,7 +45,7 @@ class Instruction:
         return self.offset
 
     @property
-    def mnemonic(self):
+    def mnemonic(self) -> str:
         """get instruction opcode mnemonic"""
         return self.opcode.name
 

--- a/dncil/cil/opcode.py
+++ b/dncil/cil/opcode.py
@@ -26,7 +26,7 @@ class OpCode:
         op_code_type: OpCodeType,
         stack_push: StackBehaviour,
         stack_pop: StackBehaviour,
-    ):
+    ) -> None:
         self.name: str = name
         self.value: OpCodeValue = value
         self.operand_type: OperandType = operand_type


### PR DESCRIPTION
This PR adds the remaining missing type annotations in the small core CIL helper classes touched by issue #8.

Changes:
- annotate `CilMethodBodyFlags.__str__`, `CilMethodBodyFlags.__repr__`, and nested `_to_print`
- annotate `Instruction.__init__` and `Instruction.mnemonic`
- annotate `OpCode.__init__`

Validation:
- `mypy dncil`
- `pytest -q`

Closes #8